### PR TITLE
feat: add template for connections details

### DIFF
--- a/ec2.go
+++ b/ec2.go
@@ -51,11 +51,22 @@ func (e *Ec2fzf) ListInstances(ec2Client *ec2.EC2) ([]*ec2.Instance, error) {
 	return instances, err
 }
 
-func (e *Ec2fzf) GetConnectionDetails(instance *ec2.Instance) string {
-	if e.options.UsePrivateIp {
-		return *instance.PrivateIpAddress
+func (e *Ec2fzf) GetConnectionDetails(instance *ec2.Instance) (string, error) {
+	var buf bytes.Buffer
+	err := e.detailTemplate.Execute(
+		&buf,
+		struct {
+			*ec2.Instance
+			UsePrivateIp bool
+		}{
+			Instance:     instance,
+			UsePrivateIp: e.options.UsePrivateIp,
+		},
+	)
+	if err != nil {
+		return "", err
 	}
-	return *instance.PublicDnsName
+	return buf.String(), nil
 }
 
 func TemplateForInstance(i *ec2.Instance, t *template.Template) (output string, err error) {

--- a/ec2fzf.go
+++ b/ec2fzf.go
@@ -20,6 +20,7 @@ type Ec2fzf struct {
 	options         Options
 	listTemplate    *template.Template
 	previewTemplate *template.Template
+	detailTemplate  *template.Template
 	ec2Sessions     []*session.Session
 }
 
@@ -49,10 +50,16 @@ func New() (*Ec2fzf, error) {
 		panic(err)
 	}
 
+	detailTemplate, err := template.New("Details").Funcs(sprig.TxtFuncMap()).Parse(options.DetailTemplate)
+	if err != nil {
+		panic(err)
+	}
+
 	return &Ec2fzf{
 		fzfInput:        new(bytes.Buffer),
 		options:         options,
 		listTemplate:    tmpl,
+		detailTemplate:  detailTemplate,
 		previewTemplate: previewTemplate,
 		ec2Sessions:     sessions,
 	}, nil
@@ -105,7 +112,7 @@ func (e *Ec2fzf) Run() {
 	}
 
 	for _, idx := range indexes {
-		details := e.GetConnectionDetails(instances[idx])
+		details, err := e.GetConnectionDetails(instances[idx])
 		if err != nil {
 			panic(err)
 		}

--- a/go.sum
+++ b/go.sum
@@ -21,9 +21,7 @@ github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF0
 github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZCSYp4Z0m2dk6cEM60=
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -144,7 +142,6 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0 h1:Laisrj+bAB6b/yJwB5Bt3ITZhGJdqmxquMKeZ+mmkFQ=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
-github.com/mitchellh/go-homedir v1.0.0 h1:vKb8ShqSby24Yrqr/yDYkuFz8d0WUjys40rvnGC8aR0=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
 github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS42BGNg=

--- a/options.go
+++ b/options.go
@@ -10,6 +10,7 @@ type Options struct {
 	UsePrivateIp    bool
 	Template        string
 	PreviewTemplate string
+	DetailTemplate  string
 	Filters         []string
 }
 
@@ -49,12 +50,14 @@ func ParseOptions() Options {
 			{{- end -}}
 		`,
 	)
+	viper.SetDefault("DetailTemplate", `{{if .UsePrivateIp}}{{.PrivateIpAddress}}{{else}}{{.PublicDnsName}}{{end}}`)
 
 	return Options{
 		Regions:         viper.GetStringSlice("Regions"),
 		UsePrivateIp:    viper.GetBool("UsePrivateIp"),
 		Template:        viper.GetString("Template"),
 		PreviewTemplate: viper.GetString("PreviewTemplate"),
+		DetailTemplate:  viper.GetString("DetailTemplate"),
 		Filters:         viper.GetStringSlice("Filters"),
 	}
 }


### PR DESCRIPTION
I needed the ability to output instance ID instead of private / public IP.. So added a way to customise the output itself through template. I have tried to keep the previous behaviour intact by using a default value for DetailTemplate.

Feel free to merge if you think this is useful.